### PR TITLE
Add support more media types of platform 

### DIFF
--- a/src/transforms/media-queries/types.js
+++ b/src/transforms/media-queries/types.js
@@ -11,7 +11,14 @@ export const defaultTypes = [
   "tv",
 ];
 export const cssnextMediaQueryTypes = ["pointer", "hover", "block-overflow"];
-export const reactNativeMediaQueryTypes = ["android", "ios"];
+export const reactNativeMediaQueryTypes = [
+  "android",
+  "dom",
+  "ios",
+  "macos",
+  "web",
+  "windows",
+];
 export const mediaQueryTypes = defaultTypes
   .concat(cssnextMediaQueryTypes)
   .concat(reactNativeMediaQueryTypes);


### PR DESCRIPTION
[React XP](https://github.com/Microsoft/reactxp/blob/b51c6d101f652c39e72210f1cdae5dee66fb5a72/src/common/Types.ts#L1279) has another supported types (`web`, `macos`, `windows`). I also need that for RN web / RN dom.

It also required to update [`react-native-css-media-query-processor`](https://github.com/kristerkari/react-native-css-media-query-processor/blob/master/src/index.js#L33).

Thank you @kristerkari!